### PR TITLE
Implement checking of validation clauses

### DIFF
--- a/packages/compiler/src/core/binder.ts
+++ b/packages/compiler/src/core/binder.ts
@@ -423,7 +423,7 @@ export function createBinder(program: Program): Binder {
   }
 
   function bindScalarStatement(node: ScalarStatementNode) {
-    declareSymbol(node, SymbolFlags.Scalar);
+    declareSymbol(node, SymbolFlags.Scalar)!;
     // Initialize locals for type parameters
     mutate(node).locals = new SymbolTable();
   }

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -3325,9 +3325,6 @@ export function createChecker(program: Program): Checker {
         const leftType = left.type.kind === "ModelProperty" ? left.type.type : left.type;
         const rightType = right.type.kind === "ModelProperty" ? right.type.type : right.type;
 
-        console.log({ leftType, rightType });
-        debugger;
-
         if (
           !isTypeAssignableTo(leftType, rightType, node)[0] &&
           !isTypeAssignableTo(rightType, leftType, node)[0]
@@ -3443,13 +3440,32 @@ export function createChecker(program: Program): Checker {
         const body = checkLogicExpression(node.body, mapper);
         if (!body) return undefined;
 
+        const opType: Operation = createAndFinishType({
+          kind: "Operation",
+          name: "",
+          namespace: undefined,
+          node: undefined as any, // todo: clean up this story
+          parameters: createAndFinishType({
+            kind: "Model",
+            node: undefined,
+            name: "",
+            indexer: undefined,
+            properties: createRekeyableMap(), // TODO: Create parameter types as unknown (will be filled in later, contextually)
+            validates: createRekeyableMap(),
+            decorators: [],
+            derivedModels: [],
+          }),
+          returnType: body.type,
+          decorators: [],
+        });
+
         return {
           logic: {
             kind: "LambdaExpression",
             parameters: node.parameters.map((x) => ({ kind: "Parameter", name: x.id.sv })),
             body: body.logic as LogicBlockExpression,
           },
-          type: unknownType, // probably should be operation type?
+          type: opType,
         };
       }
       case SyntaxKind.ProjectionCallExpression: {
@@ -3531,6 +3547,7 @@ export function createChecker(program: Program): Checker {
                 target: target.logic as LogicMemberExpression | LogicIdentifier,
                 arguments: [],
                 type,
+                referencedType,
               },
               type,
             };

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -1910,9 +1910,20 @@ export function createChecker(program: Program): Checker {
     }
 
     if (identifier.parent && identifier.parent.kind === SyntaxKind.MemberExpression) {
-      let base = resolveTypeReferenceSym(identifier.parent.base, undefined, false);
+      let base = resolveTypeReferenceSym(
+        identifier.parent.base,
+        undefined,
+        false,
+        !!parentValidate
+      );
+
       if (base) {
         if (identifier.parent.selector === ".") {
+          if (parentValidate && base.flags & SymbolFlags.ModelProperty) {
+            const metaTable = getOrCreateAugmentedSymbolTable(base.metatypeMembers!);
+            base = getAliasedSymbol(metaTable.get("type")!, undefined)!;
+          }
+          
           if (base.flags & SymbolFlags.Alias) {
             base = getAliasedSymbol(base, undefined);
           }

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -1892,7 +1892,7 @@ export function createChecker(program: Program): Checker {
 
   function resolveCompletions(identifier: IdentifierNode): Map<string, TypeSpecCompletionItem> {
     const completions = new Map<string, TypeSpecCompletionItem>();
-    const { kind } = getIdentifierContext(identifier);
+    const { kind, parentValidate } = getIdentifierContext(identifier);
 
     switch (kind) {
       case IdentifierKind.Using:
@@ -1928,6 +1928,11 @@ export function createChecker(program: Program): Checker {
       }
     } else {
       let scope: Node | undefined = identifier.parent;
+      if (parentValidate) {
+        const parentNode = parentValidate.parent! as ModelStatementNode | ScalarStatementNode;
+        addCompletions(parentNode.symbol.members);
+      }
+
       while (scope && scope.kind !== SyntaxKind.TypeSpecScript) {
         if (scope.symbol && scope.symbol.exports) {
           const mergedSymbol = getMergedSymbol(scope.symbol)!;

--- a/packages/compiler/src/core/messages.ts
+++ b/packages/compiler/src/core/messages.ts
@@ -486,6 +486,13 @@ const diagnostics = {
       default: paramMessage`Shadowing parent template parmaeter with the same name "${"name"}"`,
     },
   },
+  "type-expected": {
+    severity: "error",
+    messages: {
+      default: paramMessage`Expected type of ${"expected"} but got ${"actual"}`,
+      comparable: paramMessage`The types ${"left"} and ${"right"} are not comparable.`,
+    },
+  },
 
   /**
    * Configuration

--- a/packages/compiler/src/core/parser.ts
+++ b/packages/compiler/src/core/parser.ts
@@ -3467,6 +3467,9 @@ export function getFirstAncestor(node: Node, test: NodeCallback<boolean>): Node 
 
 export function getIdentifierContext(id: IdentifierNode): IdentifierContext {
   const node = getFirstAncestor(id, (n) => n.kind !== SyntaxKind.MemberExpression);
+  // todo: optimize by bailing out when we discover any non-expression node
+  const parentValidate = getFirstAncestor(id, (n) => n.kind === SyntaxKind.ModelValidate);
+
   compilerAssert(node, "Identifier with no non-member-expression ancestor.");
 
   let kind: IdentifierKind;
@@ -3492,5 +3495,5 @@ export function getIdentifierContext(id: IdentifierNode): IdentifierContext {
       break;
   }
 
-  return { node, kind };
+  return { node, kind, parentValidate };
 }

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -687,7 +687,7 @@ export const enum SymbolFlags {
   /**
    * Symbols whose members will be late bound (and stored on the type)
    */
-  MemberContainer = Model | Enum | Union | Interface,
+  MemberContainer = Model | Enum | Union | Interface | Scalar,
   Member = ModelProperty | EnumMember | UnionVariant | InterfaceMember | ModelValidate,
 }
 
@@ -2300,7 +2300,7 @@ export interface LogicArithmeticExpression extends LogicNodeBase, LogicBinOp {
 
 export interface LogicCallExpression extends LogicNodeBase {
   kind: "CallExpression";
-  target: LogicExpression;
+  target: LogicReferenceExpression;
   arguments: LogicExpression[];
 }
 

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -2318,6 +2318,7 @@ export interface LogicMemberExpression extends LogicNodeBase {
   id: string;
   selector: "." | "::";
   type: Type;
+  referencedType?: Type;
 }
 
 export interface LogicIfExpression extends LogicNodeBase {
@@ -2362,6 +2363,7 @@ export interface LogicIdentifier extends LogicNodeBase {
   kind: "Identifier";
   name: string;
   type: Type;
+  referencedType?: Type;
 }
 
 export interface LogicTypeKeyword extends LogicNodeBase {

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -1086,7 +1086,8 @@ export type ProjectionExpression =
   | VoidKeywordNode
   | NeverKeywordNode
   | AnyKeywordNode
-  | ReturnExpressionNode;
+  | ReturnExpressionNode
+  | ReferenceExpression;
 
 export type ReferenceExpression =
   | TypeReferenceNode
@@ -2234,6 +2235,7 @@ export type LogicExpression =
   | LogicUnaryExpression
   | LogicArithmeticExpression
   | LogicCallExpression
+  | LogicReferenceExpression
   | LogicMemberExpression
   | LogicIfExpression
   | LogicBlockExpression
@@ -2298,15 +2300,21 @@ export interface LogicArithmeticExpression extends LogicNodeBase, LogicBinOp {
 
 export interface LogicCallExpression extends LogicNodeBase {
   kind: "CallExpression";
-  callKind: "method" | "template";
   target: LogicExpression;
   arguments: LogicExpression[];
+}
+
+export interface LogicReferenceExpression extends LogicNodeBase {
+  kind: "ReferenceExpression";
+  target: LogicMemberExpression | LogicIdentifier;
+  arguments: LogicExpression[];
+  type: Type;
 }
 
 export interface LogicMemberExpression extends LogicNodeBase {
   kind: "MemberExpression";
   base: LogicExpression;
-  id: LogicIdentifier;
+  id: string;
   selector: "." | "::";
   type: Type;
 }

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -294,8 +294,8 @@ export interface ModelProperty extends BaseType, DecoratedType {
 export interface ModelValidate extends BaseType, DecoratedType {
   kind: "ModelValidate";
   node: ModelValidateNode;
+  logic: LogicExpression;
   name: string;
-
   model?: Model | Scalar;
 }
 
@@ -2222,4 +2222,141 @@ export interface Tracer {
    * @param area
    */
   sub(subarea: string): Tracer;
+}
+
+export type LogicNode = LogicStatement | LogicExpression | LogicParameter;
+export type LogicStatement = LogicExpressionStatement;
+export type LogicExpression =
+  | LogicLogicalExpression
+  | LogicRelationalExpression
+  | LogicMembershipExpression
+  | LogicEqualityExpression
+  | LogicUnaryExpression
+  | LogicArithmeticExpression
+  | LogicCallExpression
+  | LogicMemberExpression
+  | LogicIfExpression
+  | LogicBlockExpression
+  | LogicLambdaExpression
+  | LogicStringLiteral
+  | LogicBooleanLiteral
+  | LogicNumericLiteral
+  | LogicIdentifier
+  | LogicTypeKeyword;
+
+export interface LogicNodeBase {
+  kind: string;
+}
+
+export interface LogicExpressionStatement extends LogicNodeBase {
+  kind: "ExpressionStatement";
+  expr: LogicExpression;
+}
+
+export interface LogicBinOp {
+  op: string;
+  left: LogicExpression;
+  right: LogicExpression;
+}
+
+export interface LogicUnaryOp {
+  op: string;
+  target: LogicExpression;
+}
+
+export interface LogicLogicalExpression extends LogicNodeBase, LogicBinOp {
+  kind: "LogicalExpression";
+  op: "||" | "&&" | "==>";
+}
+
+export interface LogicRelationalExpression extends LogicNodeBase, LogicBinOp {
+  kind: "RelationalExpression";
+  op: "<=" | "<" | ">" | ">=";
+}
+
+export interface LogicMembershipExpression extends LogicNodeBase {
+  kind: "MembershipExpression";
+  op: "in" | "not in";
+  left: LogicExpression;
+  arguments: LogicExpression[];
+}
+
+export interface LogicEqualityExpression extends LogicNodeBase, LogicBinOp {
+  kind: "EqualityExpression";
+  op: "==" | "!=";
+}
+
+export interface LogicUnaryExpression extends LogicNodeBase, LogicUnaryOp {
+  kind: "UnaryExpression";
+  op: "!";
+}
+
+export interface LogicArithmeticExpression extends LogicNodeBase, LogicBinOp {
+  kind: "ArithmeticExpression";
+  op: "+" | "-" | "*" | "/";
+}
+
+export interface LogicCallExpression extends LogicNodeBase {
+  kind: "CallExpression";
+  callKind: "method" | "template";
+  target: LogicExpression;
+  arguments: LogicExpression[];
+}
+
+export interface LogicMemberExpression extends LogicNodeBase {
+  kind: "MemberExpression";
+  base: LogicExpression;
+  id: LogicIdentifier;
+  selector: "." | "::";
+  type: Type;
+}
+
+export interface LogicIfExpression extends LogicNodeBase {
+  kind: "IfExpression";
+  test: LogicExpression;
+  consequent: LogicBlockExpression;
+  alternate?: LogicBlockExpression | LogicIfExpression;
+}
+
+export interface LogicBlockExpression extends LogicNodeBase {
+  kind: "BlockExpression";
+  statements: LogicStatement[];
+}
+
+export interface LogicLambdaExpression extends LogicNodeBase {
+  kind: "LambdaExpression";
+  parameters: LogicParameter[];
+  body: LogicBlockExpression;
+}
+
+export interface LogicStringLiteral extends LogicNodeBase {
+  kind: "StringLiteral";
+  value: string;
+}
+
+export interface LogicNumericLiteral extends LogicNodeBase {
+  kind: "NumericLiteral";
+  value: number;
+}
+
+export interface LogicBooleanLiteral extends LogicNodeBase {
+  kind: "BooleanLiteral";
+  value: boolean;
+}
+
+export interface LogicParameter extends LogicNodeBase {
+  kind: "Parameter";
+  name: string;
+}
+
+export interface LogicIdentifier extends LogicNodeBase {
+  kind: "Identifier";
+  name: string;
+  type: Type;
+}
+
+export interface LogicTypeKeyword extends LogicNodeBase {
+  kind: "TypeKeyword";
+  name: "unknown" | "void" | "never";
+  type: UnknownType | VoidType | NeverType;
 }

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -1573,6 +1573,7 @@ export interface ProjectionDecoratorReferenceExpressionNode extends BaseNode {
 export interface IdentifierContext {
   kind: IdentifierKind;
   node: Node;
+  parentValidate?: Node;
 }
 
 export enum IdentifierKind {

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -2310,6 +2310,7 @@ export interface LogicReferenceExpression extends LogicNodeBase {
   target: LogicMemberExpression | LogicIdentifier;
   arguments: LogicExpression[];
   type: Type;
+  referencedType?: Type;
 }
 
 export interface LogicMemberExpression extends LogicNodeBase {

--- a/packages/compiler/src/server/completion.ts
+++ b/packages/compiler/src/server/completion.ts
@@ -252,6 +252,9 @@ function addIdentifierCompletion(
 }
 
 function getCompletionItemKind(program: Program, target: Type): CompletionItemKind {
+  if (target.kind === "Intrinsic") {
+    return CompletionItemKind.Function;
+  }
   switch (target.node?.kind) {
     case SyntaxKind.EnumStatement:
     case SyntaxKind.UnionStatement:

--- a/packages/compiler/test/checker/validate.test.ts
+++ b/packages/compiler/test/checker/validate.test.ts
@@ -130,4 +130,83 @@ describe("compiler: validate", () => {
 
     strictEqual(S.validates.size, 1);
   });
+
+  it.skip("resolves identifiers");
+  it.skip("resolves member expressions");
+  it.skip("converts logic expressions to a useful AST", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `  
+      @test model M {
+        ii: int64;
+        validate chkii: ii >= if true { true; } else { false; };
+      }
+      `
+    );
+
+    const { M } = (await testHost.compile("main.tsp")) as {
+      M: Model;
+    };
+
+    console.log(M.validates.get("chkii2")?.logic);
+  });
+
+  it.skip("checks that operands of logical expressions are booleans", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `  
+      @test model M {
+        ii: boolean;
+        prop: string;
+        validate chkii: 12 == true;
+      }
+      `
+    );
+
+    const { M } = (await testHost.compile("main.tsp")) as {
+      M: Model;
+    };
+  });
+
+  it.only("handles member expressions", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `  
+      @test model M {
+        n: N;
+        validate chkn: true.prop;
+      }
+
+      model N {
+        value: int64;
+      }
+      `
+    );
+
+    const { M } = (await testHost.compile("main.tsp")) as {
+      M: Model;
+    };
+
+    console.log(M.validates.get("chkn")?.logic);
+  });
+
+  it.skip("doesn't allow references decorators", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `
+      model Foo { }
+      @test scalar S extends int64 {
+        validate chkv: @doc(1);
+      }
+      `
+    );
+
+    const { S } = (await testHost.compile("main.tsp")) as {
+      S: Scalar;
+    };
+
+    strictEqual(S.validates.size, 1);
+  });
+
+  it.skip("doesn't allow model literal and tuple literal references", async () => {});
 });

--- a/packages/compiler/test/checker/validate.test.ts
+++ b/packages/compiler/test/checker/validate.test.ts
@@ -2,7 +2,7 @@ import { strictEqual } from "assert";
 import { IntrinsicType, LogicCallExpression, Model, Scalar } from "../../src/core/types.js";
 import { TestHost, createTestHost } from "../../src/testing/index.js";
 
-describe("compiler: validate", () => {
+describe.only("compiler: validate", () => {
   let testHost: TestHost;
 
   beforeEach(async () => {
@@ -219,18 +219,20 @@ describe("compiler: validate", () => {
       N: Model;
     };
 
+    // todo: test type
+
     const logic = M.validates.get("chkn")!.logic;
     strictEqual(logic.kind, "EqualityExpression");
     strictEqual(logic.left.kind, "ReferenceExpression");
-    strictEqual(logic.left.type, N.properties.get("value"));
+    strictEqual(logic.left.referencedType, N.properties.get("value"));
     strictEqual(logic.right.kind, "NumericLiteral");
 
     const memberExpr = logic.left.target;
     strictEqual(memberExpr.kind, "MemberExpression");
-    strictEqual(memberExpr.type, N.properties.get("value"));
+    strictEqual(memberExpr.referencedType, N.properties.get("value"));
     strictEqual(memberExpr.id, "value");
     strictEqual(memberExpr.base.kind, "Identifier");
-    strictEqual(memberExpr.base.type, M.properties.get("n"));
+    strictEqual(memberExpr.base.referencedType, M.properties.get("n"));
   });
 
   it.skip("allows multiple fn calls", async () => {
@@ -270,7 +272,7 @@ describe("compiler: validate", () => {
     // TODO: Validate
   });
 
-  it.only("produces union types for if statements", async () => {
+  it("produces union types for if statements", async () => {
     testHost.addTypeSpecFile(
       "main.tsp",
       `

--- a/packages/compiler/test/checker/validate.test.ts
+++ b/packages/compiler/test/checker/validate.test.ts
@@ -2,7 +2,7 @@ import { strictEqual } from "assert";
 import { IntrinsicType, LogicCallExpression, Model, Scalar } from "../../src/core/types.js";
 import { TestHost, createTestHost } from "../../src/testing/index.js";
 
-describe.only("compiler: validate", () => {
+describe("compiler: validate", () => {
   let testHost: TestHost;
 
   beforeEach(async () => {
@@ -231,6 +231,26 @@ describe.only("compiler: validate", () => {
     strictEqual(memberExpr.id, "value");
     strictEqual(memberExpr.base.kind, "Identifier");
     strictEqual(memberExpr.base.type, M.properties.get("n"));
+  });
+
+  it.skip("allows multiple fn calls", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `
+      @test model M {
+        str1: string;
+        str2: string;
+        
+        validate checkStr: str1::concat(str2)::concat(str1);
+      }
+      `
+    );
+
+    const { M } = (await testHost.compile("main.tsp")) as {
+      M: Model;
+    };
+
+    console.log(M.validates.get("checkStr")?.logic);
   });
 
   it("allows for arithmetic on scalar subtypes", async () => {

--- a/packages/compiler/test/checker/validate.test.ts
+++ b/packages/compiler/test/checker/validate.test.ts
@@ -270,6 +270,24 @@ describe("compiler: validate", () => {
     // TODO: Validate
   });
 
+  it.only("produces union types for if statements", async () => {
+    testHost.addTypeSpecFile(
+      "main.tsp",
+      `
+      @test model M {
+        string: string;
+        int32: int32;
+        numeric: numeric;
+        
+        // this check will only succeed if we properly produce a union type
+        validate c1: if (true) { string; } else { int32; } == int32;
+      }
+      `
+    );
+
+    await testHost.compile("main.tsp");
+  });
+
   it.skip("doesn't allow references decorators", async () => {
     testHost.addTypeSpecFile(
       "main.tsp",

--- a/packages/compiler/test/server/completion.test.ts
+++ b/packages/compiler/test/server/completion.test.ts
@@ -882,6 +882,60 @@ describe("compiler: server: completion", () => {
     ]);
   });
 
+  it("completes model members inside of a validate clause of model", async () => {
+    const completions = await complete(
+      `
+      model Foo {
+        prop: string;
+        prop2: string;
+        validate ┆
+      }
+      `
+    );
+    check(completions, [
+      {
+        label: "prop",
+        insertText: "prop",
+        kind: CompletionItemKind.Field,
+        documentation: {
+          kind: "markdown",
+          value: "(model property)\n```typespec\nFoo.prop: string\n```",
+        },
+      },
+      {
+        label: "prop2",
+        insertText: "prop2",
+        kind: CompletionItemKind.Field,
+        documentation: {
+          kind: "markdown",
+          value: "(model property)\n```typespec\nFoo.prop2: string\n```",
+        },
+      },
+    ]);
+  });
+
+  it("completes value member inside of a validate clause of scalar", async () => {
+    const completions = await complete(
+      `
+      scalar Foo {
+        validate ┆
+      }
+      `
+    );
+
+    check(completions, [
+      {
+        label: "value",
+        insertText: "value",
+        kind: CompletionItemKind.Unit,
+        documentation: {
+          kind: "markdown",
+          value: "```typespec\nscalar Foo\n```",
+        },
+      },
+    ]);
+  });
+
   function check(
     list: CompletionList,
     expectedItems: CompletionItem[],

--- a/packages/compiler/test/server/completion.test.ts
+++ b/packages/compiler/test/server/completion.test.ts
@@ -936,6 +936,50 @@ describe("compiler: server: completion", () => {
     ]);
   });
 
+  it("Completes meta-members of arrays", async () => {
+    const completions = await complete(
+      `
+      alias Foo = string[];
+      alias Bar = Foo::┆
+      `
+    );
+
+    check(completions, [
+      {
+        label: "min",
+        insertText: "min",
+        kind: CompletionItemKind.Function,
+        documentation: undefined,
+      },
+      {
+        label: "max",
+        insertText: "max",
+        kind: CompletionItemKind.Function,
+        documentation: undefined,
+      },
+    ]);
+  });
+
+  it("Completes meta-members of model properties", async () => {
+    const completions = await complete(
+      `
+      model Foo {
+        prop: string;
+      }
+      alias Bar = Foo.prop::┆
+      `
+    );
+
+    check(completions, [
+      {
+        label: "type",
+        insertText: "type",
+        kind: CompletionItemKind.Unit,
+        documentation: { kind: "markdown", value: "```typespec\nscalar string\n```" },
+      },
+    ]);
+  });
+
   function check(
     list: CompletionList,
     expectedItems: CompletionItem[],

--- a/packages/compiler/test/server/completion.test.ts
+++ b/packages/compiler/test/server/completion.test.ts
@@ -980,6 +980,34 @@ describe("compiler: server: completion", () => {
     ]);
   });
 
+  it.only("Completes members of the type of model property references inside validates clauses", async () => {
+    const completions = await complete(
+      `
+      model Foo {
+        bar: Bar;
+
+        validate bar.┆
+      }
+
+      model Bar {
+        prop: string;
+      }
+      `
+    );
+
+    check(completions, [
+      {
+        label: "prop",
+        insertText: "prop",
+        kind: CompletionItemKind.Field,
+        documentation: {
+          kind: "markdown",
+          value: "(model property)\n```typespec\nBar.prop: string\n```",
+        },
+      },
+    ]);
+  });
+
   function check(
     list: CompletionList,
     expectedItems: CompletionItem[],

--- a/packages/html-program-viewer/src/ui.tsx
+++ b/packages/html-program-viewer/src/ui.tsx
@@ -110,6 +110,7 @@ const omittedProps = [
   "projector",
   "projections",
   "isFinished",
+  "logic"
 ] as const;
 const omittedPropsSet = new Set(omittedProps);
 type OmittedProps = (typeof omittedProps)[number];


### PR DESCRIPTION
Initial stab at deeply checking  validation clauses to catch obvious nonsense in validation clauses (e.g. `12 > true`, `1 && "hello"`, `true + false`, etc.) and save emitters from having to implement identifier resolution themselves in order to emit validation code. Still some outstanding items to tackle:

* [ ] additional parser constraints
* [ ] checking of lambda expressions
* [ ] flowing types into lambda expressions
* [ ] fix tests, write more tests
* [ ] allow chained function calls e.g. `str::concat(“bar”)::concat(“baz")` (this may seem like low-pri but I suspect it entails breaking changes to the AST structure, tho not sure).
* [ ] Fix colorization of `::`
* [ ] String length accessors (do we have consensus on pedantic vs. not-pedantic? may need design meeting to confirm)
* [ ] Implement a test emitter that emits validation expressions in TypeScript
* [x] member expression resolution and checking
* [x] adding various library functions like `someOf`, `allOf`, `slice`, etc.