### PR TITLE
Validate function calls

### DIFF
--- a/packages/compiler/lib/main.tsp
+++ b/packages/compiler/lib/main.tsp
@@ -2,3 +2,4 @@ import "./lib.tsp";
 import "./decorators.tsp";
 import "./reflection.tsp";
 import "./projected-names.tsp";
+import "./methods.tsp";

--- a/packages/compiler/lib/methods.tsp
+++ b/packages/compiler/lib/methods.tsp
@@ -1,0 +1,45 @@
+namespace TypeSpec.ValueMethods;
+
+interface Array<TElementType> {
+  someOf(cb: Private.BooleanReturnCb<TElementType>): boolean;
+  allOf(cb: Private.BooleanReturnCb<TElementType>): boolean;
+  noneOf(cb: Private.BooleanReturnCb<TElementType>): boolean;
+  find(cb: Private.BooleanReturnCb<TElementType>): TElementType | void;
+  contains(value: TElementType): boolean;
+  first(n: numeric): TElementType[];
+  last(n: numeric): TElementType[];
+  sum(cb?: Private.NumericReturnCb<TElementType>): numeric;
+
+  /**
+   * Return the minimum value in the array. Optionally pass a callback to select the value to compare.
+   */
+  min(cb?: Private.NumericReturnCb<TElementType>): numeric;
+
+  /**
+   * Return the maximum value in the array. Optionally pass a callback to select the value to compare.
+   */
+  max(cb?: Private.NumericReturnCb<TElementType>): numeric;
+  distinct(): TElementType[];
+  length(): numeric;
+}
+
+interface String {
+  contains(value: string): boolean;
+  startsWith(value: string): boolean;
+  endsWith(value: string): boolean;
+  slice(start: numeric, end?: numeric, unit?: StringUnit = StringUnit.utf16CodeUnit): string;
+  concat(value: string): string;
+  length(unit?: StringUnit = StringUnit.utf16CodeUnit): numeric;
+}
+
+enum StringUnit {
+  codePoint,
+  utf16CodeUnit,
+  utf8CodeUnit,
+  graphemeCluster,
+}
+
+namespace Private {
+  op BooleanReturnCb<T>(value: T): boolean;
+  op NumericReturnCb<T>(value: T): numeric;
+}

--- a/packages/compiler/src/core/checker.ts
+++ b/packages/compiler/src/core/checker.ts
@@ -3528,28 +3528,32 @@ export function createChecker(program: Program): Checker {
           );
           return;
         }
+        const expectedArgTypes = [...target.type.parameters.properties.values()];
 
-        if (target.type.parameters.properties.size < node.arguments.length) {
+        const minArgs = expectedArgTypes.filter((x) => !x.optional).length;
+        const maxArgs = expectedArgTypes.length;
+
+        if (node.arguments.length < minArgs) {
           reportCheckerDiagnostic(
             createDiagnostic({
               code: "invalid-function-args",
               messageId: "tooFew",
               format: {
                 actual: String(node.arguments.length),
-                expected: String(target.type.parameters.properties.size),
+                expected: String(minArgs),
               },
               target: node,
             })
           );
           return;
-        } else if (target.type.parameters.properties.size > node.arguments.length) {
+        } else if (node.arguments.length > maxArgs) {
           reportCheckerDiagnostic(
             createDiagnostic({
               code: "invalid-function-args",
               messageId: "tooMany",
               format: {
                 actual: String(node.arguments.length),
-                expected: String(target.type.parameters.properties.size),
+                expected: String(maxArgs),
               },
               target: node,
             })
@@ -3558,7 +3562,6 @@ export function createChecker(program: Program): Checker {
         }
 
         const args = [];
-        const expectedArgTypes = [...target.type.parameters.properties.values()];
         for (let i = 0; i < node.arguments.length; i++) {
           const expectedType = expectedArgTypes[i];
           const argType = checkLogicExpression(node.arguments[i], mapper);
@@ -5673,6 +5676,9 @@ export function createChecker(program: Program): Checker {
       return isAssignableToUnion(source, target, diagnosticTarget);
     } else if (target.kind === "Enum") {
       return isAssignableToEnum(source, target, diagnosticTarget);
+    } else if (target.kind === "Operation" && source.kind === "Operation") {
+      // todo: check if the operation is assignable
+      return [true, []];
     }
 
     return [false, [createUnassignableDiagnostic(source, target, diagnosticTarget)]];

--- a/packages/compiler/src/core/helpers/operation-utils.ts
+++ b/packages/compiler/src/core/helpers/operation-utils.ts
@@ -20,6 +20,8 @@ export function listOperationsIn(
 ): Operation[] {
   const operations: Operation[] = [];
 
+  const globalNamespace = container.kind === "Namespace" && container.name === "";
+
   function addOperations(current: Namespace | Interface) {
     if (current.kind === "Interface" && isTemplateDeclaration(current)) {
       // Skip template interface operations
@@ -42,6 +44,9 @@ export function listOperationsIn(
       ];
 
       for (const child of children) {
+        if (globalNamespace && child.name === "TypeSpec" && child.namespace === container) {
+          continue;
+        }
         addOperations(child);
       }
     }

--- a/packages/compiler/src/core/helpers/usage-resolver.ts
+++ b/packages/compiler/src/core/helpers/usage-resolver.ts
@@ -68,7 +68,12 @@ function trackUsage(
 }
 
 function addUsagesInNamespace(namespace: Namespace, usages: Map<TrackableType, UsageFlags>): void {
+  const globalNamespace = namespace.name === "";
+
   for (const subNamespace of namespace.namespaces.values()) {
+    if (globalNamespace && subNamespace.name === "TypeSpec") {
+      continue;
+    }
     addUsagesInNamespace(subNamespace, usages);
   }
   for (const Interface of namespace.interfaces.values()) {

--- a/packages/compiler/src/core/messages.ts
+++ b/packages/compiler/src/core/messages.ts
@@ -486,6 +486,10 @@ const diagnostics = {
       default: paramMessage`Shadowing parent template parmaeter with the same name "${"name"}"`,
     },
   },
+
+  /**
+   * Validation clause
+   */
   "type-expected": {
     severity: "error",
     messages: {
@@ -494,6 +498,15 @@ const diagnostics = {
     },
   },
 
+  "invalid-function-args": {
+    severity: "error",
+    messages: {
+      default: paramMessage`Invalid arguments for function "${"name"}".`,
+      tooFew: paramMessage`Too few arguments. Expected at least ${"expected"} arguments but got ${"actual"}.`,
+      tooMany: paramMessage`Too many arguments. Expected at most ${"expected"} arguments but got ${"actual"}.`,
+      incorrect: paramMessage`Argument '${"name"}' has incorrect type. Expected ${"expected"} but got ${"actual"}.`,
+    },
+  },
   /**
    * Configuration
    */

--- a/packages/compiler/src/core/messages.ts
+++ b/packages/compiler/src/core/messages.ts
@@ -502,8 +502,8 @@ const diagnostics = {
     severity: "error",
     messages: {
       default: paramMessage`Invalid arguments for function "${"name"}".`,
-      tooFew: paramMessage`Too few arguments. Expected at least ${"expected"} arguments but got ${"actual"}.`,
-      tooMany: paramMessage`Too many arguments. Expected at most ${"expected"} arguments but got ${"actual"}.`,
+      tooFew: paramMessage`Too few arguments. Expected at least ${"expected"} argument(s) but got ${"actual"}.`,
+      tooMany: paramMessage`Too many arguments. Expected at most ${"expected"} argument(s) but got ${"actual"}.`,
       incorrect: paramMessage`Argument '${"name"}' has incorrect type. Expected ${"expected"} but got ${"actual"}.`,
     },
   },

--- a/packages/compiler/src/core/types.ts
+++ b/packages/compiler/src/core/types.ts
@@ -208,6 +208,8 @@ export type IntrinsicScalarName =
   | "boolean"
   | "url";
 
+export type MetaMemberKey = Type["kind"] | "Array" | "String";
+
 export type NeverIndexer = { key: NeverType; value: undefined };
 export type ModelIndexer = {
   key: Scalar;

--- a/packages/compiler/test/checker/validate.test.ts
+++ b/packages/compiler/test/checker/validate.test.ts
@@ -427,10 +427,13 @@ describe("compiler: validate", () => {
       "main.tsp",
       `
       @test model M {
-        prop: string[];
+        prop: numeric[];
 
         validate check: prop::contains();
-        validate check2: prop::contains("hi", "hi");
+        validate check2: prop::contains(1, 2);
+        validate check3: prop::sum(); // ok
+        validate check4: prop::sum((v) => { v; }); // ok
+        validate check5: prop::sum((v) => { v; }, 1); // error
       }
       `
     );
@@ -439,11 +442,15 @@ describe("compiler: validate", () => {
     expectDiagnostics(diagnostics, [
       {
         code: "invalid-function-args",
-        message: /Too many arguments. Expected at most 1 arguments but got 0./,
+        message: /Too few arguments. Expected at least 1 argument\(s\) but got 0./,
       },
       {
         code: "invalid-function-args",
-        message: /Too few arguments. Expected at least 1 arguments but got 2./,
+        message: /Too many arguments. Expected at most 1 argument\(s\) but got 2./,
+      },
+      {
+        code: "invalid-function-args",
+        message: /Too many arguments. Expected at most 1 argument\(s\) but got 2./,
       },
     ]);
   });

--- a/packages/compiler/test/checker/validate.test.ts
+++ b/packages/compiler/test/checker/validate.test.ts
@@ -1,5 +1,5 @@
 import { notStrictEqual, strictEqual } from "assert";
-import { IntrinsicType, LogicCallExpression, Model, Scalar } from "../../src/core/types.js";
+import { LogicCallExpression, Model, Operation, Scalar } from "../../src/core/types.js";
 import { TestHost, createTestHost, expectDiagnostics } from "../../src/testing/index.js";
 
 describe.only("compiler: validate", () => {
@@ -271,7 +271,7 @@ describe.only("compiler: validate", () => {
     ]);
   });
 
-  it("can resolve built-in functions", async () => {
+  it.only("can resolve built-in functions", async () => {
     testHost.addTypeSpecFile(
       "main.tsp",
       `
@@ -289,11 +289,11 @@ describe.only("compiler: validate", () => {
     };
 
     const checkItems = M.validates.get("checkItems")!.logic as LogicCallExpression;
-    strictEqual((checkItems.target.type as IntrinsicType).name, "Array::someOf");
+    strictEqual((checkItems.target.type as Operation).name, "someOf");
     strictEqual(checkItems.arguments[0].kind, "LambdaExpression");
 
     const validateStr = M.validates.get("checkStr")!.logic as LogicCallExpression;
-    strictEqual((validateStr.target.type as IntrinsicType).name, "String::startsWith");
+    strictEqual((validateStr.target.type as Operation).name, "startsWith");
     strictEqual(validateStr.arguments[0].kind, "StringLiteral");
   });
 

--- a/packages/compiler/test/checker/validate.test.ts
+++ b/packages/compiler/test/checker/validate.test.ts
@@ -2,7 +2,7 @@ import { notStrictEqual, strictEqual } from "assert";
 import { LogicCallExpression, Model, Operation, Scalar } from "../../src/core/types.js";
 import { TestHost, createTestHost, expectDiagnostics } from "../../src/testing/index.js";
 
-describe.only("compiler: validate", () => {
+describe("compiler: validate", () => {
   let testHost: TestHost;
 
   beforeEach(async () => {
@@ -271,7 +271,7 @@ describe.only("compiler: validate", () => {
     ]);
   });
 
-  it.only("can resolve built-in functions", async () => {
+  it("can resolve built-in functions", async () => {
     testHost.addTypeSpecFile(
       "main.tsp",
       `

--- a/packages/compiler/test/server/completion.test.ts
+++ b/packages/compiler/test/server/completion.test.ts
@@ -948,14 +948,22 @@ describe("compiler: server: completion", () => {
       {
         label: "min",
         insertText: "min",
-        kind: CompletionItemKind.Function,
-        documentation: undefined,
+        kind: CompletionItemKind.Method,
+        documentation: {
+          kind: "markdown",
+          value:
+            "```typespec\nop TypeSpec.ValueMethods.min(cb: TypeSpec.ValueMethods.Private.NumericReturnCb): numeric\n```",
+        },
       },
       {
         label: "max",
         insertText: "max",
-        kind: CompletionItemKind.Function,
-        documentation: undefined,
+        kind: CompletionItemKind.Method,
+        documentation: {
+          kind: "markdown",
+          value:
+            "```typespec\nop TypeSpec.ValueMethods.max(cb: TypeSpec.ValueMethods.Private.NumericReturnCb): numeric\n```",
+        },
       },
     ]);
   });
@@ -980,7 +988,7 @@ describe("compiler: server: completion", () => {
     ]);
   });
 
-  it.only("Completes members of the type of model property references inside validates clauses", async () => {
+  it("Completes members of the type of model property references inside validates clauses", async () => {
     const completions = await complete(
       `
       model Foo {


### PR DESCRIPTION
This PR implements value methods in TypeSpec rather than as manually constructed intrinsics. This allows for checking that the proper argument types are passed, which is done. It will also enable support for the eventual contextual typing of lambda arguments, which is forthcoming.